### PR TITLE
QRの読み取り処理の修正

### DIFF
--- a/src/main/webapp/js/checkin-qr.js
+++ b/src/main/webapp/js/checkin-qr.js
@@ -43,52 +43,6 @@ function decodeQR(data) {
     img.src = data;
     img.onload = function() {
     	var canvas = document.createElement("canvas");
-    	var limitSize = 400;
-    	var resizedWidth = img.width;
-    	var resizedHeight = img.height;
-    	if (resizedWidth > limitSize || resizedHeight > limitSize) {
-    		var s;
-    		if (resizedWidth > resizedHeight) {
-    			s = limitSize / resizedWidth;
-    		} else {
-    			s = limitSize / resizedHeight;
-    		}
-    		resizedWidth *= s;
-    		resizedHeight *= s;
-    	}
-    	canvas.width = limitSize;
-    	canvas.height = limitSize;
-    	if (canvas.style.width > canvas.style.height) {
-    		canvas.style.width = resizedWidth;
-    		canvas.style.height = resizedHeight;
-    	} else {
-    		canvas.style.width = resizedWidth;
-    		canvas.style.height = resizedHeight;
-    	}
-    	var mpImg = new MegaPixImage(img);
-    	mpImg.render(canvas, { width: canvas.width, height: canvas.height });
-    	binarization(canvas, 110);
-    	var resized_data = canvas.toDataURL("image/png");
-    	qrcode.decode(resized_data);
+    	qrcode.decode(canvas.toDataURL("image/png"));
     };
-}
-
-function binarization(canvas, blackBorder) {
-	var ctx = canvas.getContext("2d");
-	var src = ctx.getImageData(0, 0, canvas.width, canvas.height);
-	var dst = ctx.createImageData(canvas.width, canvas.height);
-	for (var i = 0; i < src.data.length; i += 4) {
-		var v = src.data[i] + src.data[i+1] + src.data[i+2];
-		var c;
-		if (v <= blackBorder * 3) {
-		c = 0;
-		} else {
-		c = 255;
-		}
-		dst.data[i] = c;
-		dst.data[i+1] = c;
-		dst.data[i+2] = c;
-		dst.data[i+3] = src.data[i+3];
-	}
-	ctx.putImageData(dst, 0, 0);
 }

--- a/src/main/webapp/js/qr/qrcode.js
+++ b/src/main/webapp/js/qr/qrcode.js
@@ -130,7 +130,7 @@ qrcode.process = function(ctx){
     var start = new Date().getTime();
 
     var image = qrcode.grayScaleToBitmap(qrcode.grayscale());
-    //var image = qrcode.binarize(128);
+    image = qrcode.binarize(128);
     
     if(qrcode.debug)
     {


### PR DESCRIPTION
@yuu-nkjm 
[Web上で QR コードを読むページ(QRコードリーダー)を作成しました - 強火で進め](http://d.hatena.ne.jp/nakamura001/20141204/1417701203) にあったQRの読み込みですが、

上記サイトの方式で、画像のリサイズと2値化を行っていましたが、内部で使っている[QRコード解析ライブラリ](https://github.com/LazarSoft/jsqrcode) にも、同様の処理が書かれていましたので、そちらを使うようにしました。（ただ、2値化処理はコメントアウトされていたので、コメントアウトを外しました）

