### PR TITLE
チェックポイントのマーカーカラーを指定できるように

### DIFF
--- a/src/main/java/org/magcruise/citywalk/ApplicationContext.java
+++ b/src/main/java/org/magcruise/citywalk/ApplicationContext.java
@@ -120,7 +120,7 @@ public class ApplicationContext implements ServletContextListener {
 			}
 
 			json.addCheckpoint(new CheckpointJson(d.getCheckpointid(), d.getName(), d.getLabel(),
-					d.getLat(), d.getLon(), Arrays.asList(checkpointGroupId)));
+					d.getLat(), d.getLon(), Arrays.asList(checkpointGroupId), d.getMarkerColor()));
 			json.addTask(
 					new TaskJson(d.getCheckpointid() + "-qr", Arrays.asList(d.getCheckpointid()),
 							new ContentJson(QrCodeTask.class.getName(), true, d.getPoint(),

--- a/src/main/java/org/magcruise/citywalk/conv/CheckpointsAndTasksFactory.java
+++ b/src/main/java/org/magcruise/citywalk/conv/CheckpointsAndTasksFactory.java
@@ -70,7 +70,7 @@ public class CheckpointsAndTasksFactory {
 		List<Checkpoint> checkpoints = checkpointsData.stream()
 				.map(checkpoint -> new Checkpoint(checkpoint.getId(), checkpoint.getName(),
 						checkpoint.getLabel(), checkpoint.getLat(), checkpoint.getLon(),
-						checkpoint.getCheckpointGroupIds()))
+						checkpoint.getCheckpointGroupIds(), checkpoint.getMarkerColor()))
 				.collect(Collectors.toList());
 		return checkpoints;
 	}

--- a/src/main/java/org/magcruise/citywalk/conv/InitialDataFactory.java
+++ b/src/main/java/org/magcruise/citywalk/conv/InitialDataFactory.java
@@ -55,7 +55,7 @@ public class InitialDataFactory {
 					taskJsons.add(0, checkinTaskJson);
 					
 					return new CheckpointJson(c.getId(), c.getName(), c.getLabel(), c.getLat(),
-							c.getLon(), checkin, taskJsons);
+							c.getLon(), checkin, taskJsons, c.getMarkerColor());
 				}).collect(Collectors.toList());
 		return new InitialDataJson(result);
 

--- a/src/main/java/org/magcruise/citywalk/model/gdata/GoogleSpreadsheetData.java
+++ b/src/main/java/org/magcruise/citywalk/model/gdata/GoogleSpreadsheetData.java
@@ -21,6 +21,7 @@ public class GoogleSpreadsheetData {
 	private String description;
 	private String imgsrc;
 	private String answerqr;
+	private String markercolor;
 
 	public int getRownum() {
 		return rownum;
@@ -161,5 +162,13 @@ public class GoogleSpreadsheetData {
 
 	public void setAnswerqr(String answerqr) {
 		this.answerqr = answerqr;
+	}
+	
+	public String getMarkerColor() {
+		return markercolor;
+	}
+
+	public void setMarkerColor(String markercolor) {
+		this.markercolor = markercolor;
 	}
 }

--- a/src/main/java/org/magcruise/citywalk/model/json/db/CheckpointJson.java
+++ b/src/main/java/org/magcruise/citywalk/model/json/db/CheckpointJson.java
@@ -13,18 +13,20 @@ public class CheckpointJson {
 	private double lat;
 	private double lon;
 	private List<String> checkpointGroupIds = new ArrayList<>();
+	private String markerColor;
 
 	public CheckpointJson() {
 	}
 
 	public CheckpointJson(String id, String name, String label, double lat, double lon,
-			List<String> checkPointGroupIds) {
+			List<String> checkPointGroupIds, String markerColor) {
 		this.id = id;
 		this.name = name;
 		this.label = label;
 		this.lat = lat;
 		this.lon = lon;
 		this.checkpointGroupIds.addAll(checkPointGroupIds);
+		this.markerColor = markerColor;
 	}
 
 	public String getId() {
@@ -74,10 +76,17 @@ public class CheckpointJson {
 	public void setCheckpointGroupIds(List<String> checkpointGroupIds) {
 		this.checkpointGroupIds = checkpointGroupIds;
 	}
+	
+	public String getMarkerColor() {
+		return markerColor;
+	}
 
+	public void setMarkerColor(String markerColor) {
+		this.markerColor = markerColor;
+	}
+	
 	@Override
 	public String toString() {
 		return ToStringBuilder.reflectionToString(this, ToStringStyle.SHORT_PREFIX_STYLE);
 	}
-
 }

--- a/src/main/java/org/magcruise/citywalk/model/json/init/CheckpointJson.java
+++ b/src/main/java/org/magcruise/citywalk/model/json/init/CheckpointJson.java
@@ -16,12 +16,13 @@ public class CheckpointJson {
 
 	private CheckinJson checkin;
 	private List<TaskJson> tasks;
+	private String markerColor;
 
 	public CheckpointJson() {
 	}
 
 	public CheckpointJson(String id, String name, String label, double lat, double lon,
-			CheckinJson checkin, List<TaskJson> tasks) {
+			CheckinJson checkin, List<TaskJson> tasks, String markerColor) {
 		this.id = id;
 		this.name = name;
 		this.label = label;
@@ -29,6 +30,7 @@ public class CheckpointJson {
 		this.lon = lon;
 		this.checkin = checkin;
 		this.tasks = tasks;
+		this.markerColor = markerColor;
 	}
 
 	public String getId() {
@@ -91,5 +93,12 @@ public class CheckpointJson {
 	public void setLabel(String label) {
 		this.label = label;
 	}
+	
+	public String getMarkerColor() {
+		return markerColor;
+	}
 
+	public void setMarkerColor(String markerColor) {
+		this.markerColor = markerColor;
+	}
 }

--- a/src/main/java/org/magcruise/citywalk/model/relation/CheckpointsTable.java
+++ b/src/main/java/org/magcruise/citywalk/model/relation/CheckpointsTable.java
@@ -20,6 +20,7 @@ public class CheckpointsTable extends RelationalModel<Checkpoint> {
 	private static final String NAME = "name";
 	private static final String LABEL = "label";
 	private static final String CREATED = "created";
+	private static final String MARKER_COLOR = "marker_color";
 
 	public CheckpointsTable() {
 		super(TABLE_NAME, ApplicationContext.getDbClient());
@@ -30,6 +31,7 @@ public class CheckpointsTable extends RelationalModel<Checkpoint> {
 		setAttribute(LAT, Keyword.DOUBLE);
 		setAttribute(LON, Keyword.DOUBLE);
 		setAttribute(CHECKPOINT_GROUP_IDS, Keyword.VARCHAR);
+		setAttribute(MARKER_COLOR, Keyword.VARCHAR);
 	}
 
 	public List<Checkpoint> findByCheckpointGroupId(String checkpointGroupId) {

--- a/src/main/java/org/magcruise/citywalk/model/row/Checkpoint.java
+++ b/src/main/java/org/magcruise/citywalk/model/row/Checkpoint.java
@@ -23,18 +23,20 @@ public class Checkpoint {
 	private double lat;
 	private double lon;
 	private List<String> checkpointGroupIds = new ArrayList<>();
+	private String markerColor;
 
 	public Checkpoint() {
 	}
 
 	public Checkpoint(String id, String name, String label, double lat, double lon,
-			List<String> checkPointGroupIds) {
+			List<String> checkPointGroupIds, String markerColor) {
 		this.id = id;
 		this.name = name;
 		this.label = label;
 		this.lat = lat;
 		this.lon = lon;
 		this.checkpointGroupIds.addAll(checkPointGroupIds);
+		this.markerColor = markerColor;
 	}
 
 	public String getId() {
@@ -108,5 +110,12 @@ public class Checkpoint {
 	public void setCreated(Date created) {
 		this.created = created;
 	}
+	
+	public String getMarkerColor() {
+		return markerColor;
+	}
 
+	public void setMarkerColor(String markerColor) {
+		this.markerColor = markerColor;
+	}
 }

--- a/src/main/webapp/js/checkpoints.js
+++ b/src/main/webapp/js/checkpoints.js
@@ -121,6 +121,7 @@ function initMap() {
 		var marker = new google.maps.Marker({
 		    position: {lat: checkpoint.lat, lng: checkpoint.lon},
 		    map: map,
+		    icon: "http://maps.google.com/mapfiles/ms/icons/" + checkpoint.markerColor + "-dot.png"
 		});
 		marker.addListener('click', function() {
 		    selectCheckpoint(i);

--- a/src/main/webapp/json/checkpoints-and-tasks/waseda.json
+++ b/src/main/webapp/json/checkpoints-and-tasks/waseda.json
@@ -6,6 +6,7 @@
       "lon": 139.708019,
       "name": "大食堂",
       "label": "お昼は激こみ",
+      "marker_color": "red",
       "checkpoint_group_ids": ["waseda"]
     },
     {
@@ -14,6 +15,7 @@
       "lon": 139.705188,
       "name": "PCルーム",
       "label": "みんなで課題",
+      "marker_color": "green",
       "checkpoint_group_ids": ["waseda"]
     },
     {
@@ -22,6 +24,7 @@
       "lon": 139.706716,
       "name": "aed1",
       "label": "場所を知っておこう",
+      "marker_color": "blue",
       "checkpoint_group_ids": ["waseda"]
     },
     {
@@ -30,6 +33,7 @@
       "lon": 139.706664,
       "name": "aed2",
       "label": "マルチタスク",
+      "marker_color": "blue",
       "checkpoint_group_ids": ["waseda"]
     },
     {
@@ -38,6 +42,7 @@
       "lon": 139.70827,
       "name": "aed3",
       "label": "タスクなし",
+      "marker_color": "blue",
       "checkpoint_group_ids": ["waseda"]
     },
     {
@@ -46,6 +51,7 @@
       "lon": 139.707068,
       "name": "aed4",
       "label": "場所を知っておこう",
+      "marker_color": "blue",
       "checkpoint_group_ids": ["waseda"]
     },
     {
@@ -54,6 +60,7 @@
       "lon": 139.705007,
       "name": "aed5",
       "label": "場所を知っておこう",
+      "marker_color": "blue",
       "checkpoint_group_ids": ["waseda"]
     },
     {
@@ -62,6 +69,7 @@
       "lon": 139.707198,
       "name": "aed6",
       "label": "場所を知っておこう",
+      "marker_color": "blue",
       "checkpoint_group_ids": ["waseda"]
     }
   ],

--- a/src/test/java/org/magcruise/citywalk/model/TableModelTest.java
+++ b/src/test/java/org/magcruise/citywalk/model/TableModelTest.java
@@ -34,16 +34,16 @@ public class TableModelTest {
 		checkpoints.remakeTable();
 		checkpoints.merge(
 				new Checkpoint("aed-1", "aed-1", "A号館のAED", 38.4400, 134.11090,
-						Arrays.asList("waseda")));
+						Arrays.asList("waseda"), "blue"));
 		checkpoints.merge(
 				new Checkpoint("aed-2", "aed-2", "B号館のAED", 38.4400, 134.11090,
-						Arrays.asList("waseda")));
+						Arrays.asList("waseda"), "blue"));
 		checkpoints.merge(
 				new Checkpoint("cafeteria", "食堂", "みんながいく食堂", 38.4400, 134.11090,
-						Arrays.asList("waseda")));
+						Arrays.asList("waseda"), "red"));
 		checkpoints.merge(
 				new Checkpoint("pc-room", "PCルーム", "演習で使うPCルーム", 38.4400, 134.11090,
-						Arrays.asList("waseda")));
+						Arrays.asList("waseda"), "green"));
 		log.debug(checkpoints.readAll());
 
 		TasksTable tasks = new TasksTable();


### PR DESCRIPTION
#56 
![2016-09-28 23 03 40](https://cloud.githubusercontent.com/assets/907388/18916622/fbc25112-85cf-11e6-9593-46bc965d23cb.png)

@ieiri0104 @yuu-nkjm チェックポイントに`marker_color`を追加することで、上記のスクリーンショットのように、動的に色を変更できます。
利用可能な色は、red, blue, green, purple, yellow, orangeです。

```
{
  "checkpoints": [
    {
      "id":"cafeteria",
      "lat": 35.706489,
      "lon": 139.708019,
      "name": "大食堂",
      "label": "お昼は激こみ",
      "marker_color": "red",
      "checkpoint_group_ids": ["waseda"]
    },
```
