### PR TITLE
チェックイン後にタスクをしなかった場合途中から始められるように

### DIFF
--- a/src/main/webapp/js/navi.js
+++ b/src/main/webapp/js/navi.js
@@ -15,7 +15,9 @@ var KEY_MOVEMENT_LIST = "movement_list";
 $(function() {
 	$("#activity-title").text(checkpoint.name+"でのアクティビティ");
 	$("#btn-next").click(function() {
-		location.href = getTaskURLWithCurrentPosition(checkpoint, 0, cPos);
+		// 既に途中までタスクが進んでいる場合には、完了済みの次のタスクからはじめる
+		var taskIndex = (checkpoint.id in getCheckpointProgressDic()) ? getCheckpointProgressDic()[checkpoint.id] + 1 : 0;
+		location.href = getTaskURLWithCurrentPosition(checkpoint, taskIndex, cPos);
 	});
 
 	// コンパス画像の要素

--- a/src/main/webapp/js/util.js
+++ b/src/main/webapp/js/util.js
@@ -5,6 +5,7 @@ var KEY_GROUP_ID = "group_id";
 var KEY_CHECKPOINT_GROUP_ID = "checkpoint_group_id";
 var KEY_VISITED_CHECKPOINTS = "visited_checkpoints";
 var KEY_ANSWER_DIC = "answer_dic";
+var KEY_CHECKPOINT_PROGRESS_DIC = "checkpoint_progress_dic";
 /** *********** */
 
 $(function() {
@@ -121,6 +122,16 @@ function getNonVisitedCheckPoints() {
 		return visitedCheckPointIds.indexOf(checkpoint.id) < 0;
 	});
 	return visitedCheckPoints;
+}
+
+function getCheckpointProgressDic() {
+	return JSON.parse(getItem(KEY_CHECKPOINT_PROGRESS_DIC)) || {};
+}
+
+function setCheckpointProgress(checkpointId, taskIndex) {
+	var checkpointProgressDic = getCheckpointProgressDic();
+	checkpointProgressDic[checkpointId] = taskIndex;
+	setItem(KEY_CHECKPOINT_PROGRESS_DIC, JSON.stringify(checkpointProgressDic));
 }
 
 /* Local Storage */

--- a/src/main/webapp/js/visited-checkpoints.js
+++ b/src/main/webapp/js/visited-checkpoints.js
@@ -11,6 +11,11 @@ function showVisitedCheckPoints(results) {
 		var resultHtml = makeResultHtml(result);
 		var answerHtml = "";
 		checkpoint.tasks.forEach(function(task) {
+			// チェックイン済みだが、タスクをまだ解いてない場合には表示しない。
+			if (answerDic[checkpoint.id] == null || answerDic[checkpoint.id][task.id] == null) {
+				return;
+			}
+			
 			if (task.taskType === "DescriptionTask") {
 				answerHtml += '問題：' + task.label + '<br/>正解：' + task.answerTexts.join('、') + '<br/>回答：' + answerDic[checkpoint.id][task.id];
 			} else if (task.taskType === "SelectionTask") {

--- a/src/main/webapp/js/visited-checkpoints.js
+++ b/src/main/webapp/js/visited-checkpoints.js
@@ -10,12 +10,10 @@ function showVisitedCheckPoints(results) {
 		var result = getResultByCheckpoint(results, checkpoint);
 		var resultHtml = makeResultHtml(result);
 		var answerHtml = "";
-		checkpoint.tasks.forEach(function(task) {
-			// チェックイン済みだが、タスクをまだ解いてない場合には表示しない。
-			if (answerDic[checkpoint.id] == null || answerDic[checkpoint.id][task.id] == null) {
+		checkpoint.tasks.forEach(function(task, index) {
+			if (!(checkpoint.id in answerDic) || !(task.id in answerDic[checkpoint.id])) {
 				return;
 			}
-			
 			if (task.taskType === "DescriptionTask") {
 				answerHtml += '問題：' + task.label + '<br/>正解：' + task.answerTexts.join('、') + '<br/>回答：' + answerDic[checkpoint.id][task.id];
 			} else if (task.taskType === "SelectionTask") {
@@ -30,6 +28,10 @@ function showVisitedCheckPoints(results) {
 					}
 				}
 				answerHtml += '問題：' + task.label + '<br/>正解：' + answerTexts.join('、') + '<br/>回答：' + userAnswerTexts.join('、');
+			}
+			// 改行
+			if (index != checkpoint.tasks.length - 1) {
+				answerHtml += '<br/><br/>';
 			}
 		});
 		var html =  '<div class="row checkpoint">' +


### PR DESCRIPTION
#97 

チェックイン後にタスクをしなかった場合途中から始められるように修正しました。
また、**全てのタスクが終わった際に、訪問済みと見なし**、未訪問チェックポイント画面から訪問済みチェックポイント画面に表示が切り替わるようになっています。

これにより、チェックイン後にタスクをしなかったときに訪問済みチェックポイント表示でエラーが起こることもなくなりました。（念のため、エラーは出ないように修正も加えました）

これまでとは少し仕様が変わるのですが、この遷移自体が特殊ケースなため、こちらで修正とさせて頂ければと思います。