### PR TITLE
#130 Dbのコンテキストパス毎の切りかえ

### DIFF
--- a/src/main/java/org/magcruise/citywalk/ApplicationContext.java
+++ b/src/main/java/org/magcruise/citywalk/ApplicationContext.java
@@ -44,12 +44,6 @@ public class ApplicationContext implements ServletContextListener {
 
 	static {
 		H2Server.start();
-		DbConfig conf = H2ConfigFactory
-				.create(FileUtils.getFileInUserDirectory("magcruise-h2/citywalk"));
-		log.info(conf);
-		if (client == null) {
-			client = DbClientFactory.createH2ClientWithConnectionPool(conf);
-		}
 	}
 
 	public static DbClient getDbClient() {
@@ -58,6 +52,13 @@ public class ApplicationContext implements ServletContextListener {
 
 	@Override
 	public void contextInitialized(ServletContextEvent event) {
+		DbConfig conf = H2ConfigFactory
+				.create(FileUtils.getFileInUserDirectory("magcruise-h2/"
+						+ event.getServletContext().getContextPath() + "/citywalk"));
+		log.info(conf);
+		if (client == null) {
+			client = DbClientFactory.createH2ClientWithConnectionPool(conf);
+		}
 		initializeDatabase(event);
 		log.info("initialized");
 	}


### PR DESCRIPTION
@ayakix 
Webアプリケーションの初期化をするタイミングで，dbを設定するようにした．
``client`` は これより前にアクセスされることはない．

```java
	@Override
	public void contextInitialized(ServletContextEvent event) {
		DbConfig conf = H2ConfigFactory
				.create(FileUtils.getFileInUserDirectory("magcruise-h2/"
						+ event.getServletContext().getContextPath() + "/citywalk"));
		log.info(conf);
		if (client == null) {
			client = DbClientFactory.createH2ClientWithConnectionPool(conf);
		}
		initializeDatabase(event);
```

OKであればマージして下さい．

@ayakix , @ieiri0104 
また，これにともなって，jdbcURLが変わることにご注意下さい．

#130 