### PR TITLE
intro, how-to-useページのボタンスタイルの修正

### DIFF
--- a/src/main/webapp/css/common.css
+++ b/src/main/webapp/css/common.css
@@ -173,3 +173,6 @@ h1 {
   margin-top: 30px;
   margin-bottom: 30px;
   width: 100%; }
+
+.bottom-margin {
+  margin-bottom: 20px; }

--- a/src/main/webapp/css/common.css
+++ b/src/main/webapp/css/common.css
@@ -105,6 +105,13 @@ a:hover {
   .btn-post:hover {
     background-color: #FF972B; }
 
+.btn-group > .btn:last-child:not(:first-child), .btn-group > .dropdown-toggle:not(:first-child) {
+  border-radius: 5px;
+  -webkit-border-radius: 5px;
+  -m-border-radius: 5px;
+  -o-border-radius: 5px;
+  -ms-border-radius: 5px; }
+
 .fs3 {
   font-size: 21px; }
 

--- a/src/main/webapp/jaxrs-view-root/how-to-use.html
+++ b/src/main/webapp/jaxrs-view-root/how-to-use.html
@@ -113,7 +113,7 @@
         <h4>ヘルプ (使い方の確認)</h4>
         <p>ユーザ登録後，画面上部右端の「メニュー」ボタンをクリックするとメニューが表示されます．「使い方」を選ぶとこのページが見られます．</p>
         <br>
-        <div class="initial btn-group btn-group-justified">
+        <div class="initial btn-group btn-group-justified bottom-margin">
           <a class="btn btn-primary" href="signup.html">はじめる</a>
         </div>
       </div>

--- a/src/main/webapp/jaxrs-view-root/intro.html
+++ b/src/main/webapp/jaxrs-view-root/intro.html
@@ -85,7 +85,7 @@
           </li>
           <li><strong>移動するときは周辺の状況に十分注意してご利用下さい．</strong></li>
         </ul>
-        <div class="btn-group btn-group-justified">
+        <div class="btn-group btn-group-justified bottom-margin">
           <a id="login" class="btn btn-default" href="login.html">ログイン</a> <a id="initial"
             class="btn btn-primary" href="how-to-use.html">ワセナビに参加</a>
         </div>

--- a/src/main/webapp/scss/common.scss
+++ b/src/main/webapp/scss/common.scss
@@ -194,3 +194,7 @@ h1 {
   margin-bottom: $xLargeMargin;
   width: 100%;
 }
+
+.bottom-margin {
+  margin-bottom: $largeMargin;
+}

--- a/src/main/webapp/scss/common.scss
+++ b/src/main/webapp/scss/common.scss
@@ -121,6 +121,10 @@ a:hover {
   }
 }
 
+.btn-group>.btn:last-child:not(:first-child), .btn-group>.dropdown-toggle:not(:first-child) {
+	@include round(5px);
+}
+
 .fs3 {
   font-size: $fs3;
 }


### PR DESCRIPTION
![2016-10-24 22 48 37](https://cloud.githubusercontent.com/assets/907388/19648140/239cfebe-9a3c-11e6-9de2-f9dd023b6cf9.png)

## intro.html
* `ワセナビに参加`ボタンの左上下に角丸を追加

## intro.html, how-to-use.html
* ボタン下部にマージンを設けて押しやすくする。