### PR TITLE
#206 window.navigator.geolocation.watchPosition でのエラー処理を変更

### DIFF
--- a/src/main/webapp/js/navi.js
+++ b/src/main/webapp/js/navi.js
@@ -154,6 +154,7 @@ function watchCurrentPosition() {
     if ($('.compass-error-msg').is(':visible')) {
       $('.error-msg-splitter').show();
     }
+    return;
   }
   watchID = window.navigator.geolocation.watchPosition(function(pos) {
     $('#distance-wrapper').show();
@@ -176,6 +177,7 @@ function watchCurrentPosition() {
       $('.error-msg-splitter').show();
     }
     navigator.geolocation.clearWatch(watchID);
+    setTimeout(watchCurrentPosition, 5000);
   }, {
     enableHighAccuracy: true,
     timeout: 1000 * 60 * 60 * 2,


### PR DESCRIPTION
@ayakix 

``` js
navigator.geolocation.clearWatch(watchID);
```

これを消すだけでもいいかなと思ったけど，GPSがオンになっていない端末で早いタイミングで
errorが呼ばれ続けるので，delayさせた方が良さそう．

これならcurrentPostionで(setTimeout使った)再帰呼び出ししても良さそうですね．

レビューをお願いします．
