### PR TITLE
ServiceWorkrの修正，addActivityのオフライン対応

### DIFF
--- a/src/main/java/org/magcruise/citywalk/jaxrs/CityWalkView.java
+++ b/src/main/java/org/magcruise/citywalk/jaxrs/CityWalkView.java
@@ -21,6 +21,10 @@ public class CityWalkView extends JaxrsView {
 				response.sendRedirect(getServletUrl() + "/index.html");
 				return createView("/index.html", new ThymeleafModel());
 			}
+			if (isFromServiceWorker(params)) {
+				return createView(filePathFromViewRoot, new ThymeleafModel());
+			}
+
 			if (isUnneededLogin(filePathFromViewRoot)) {
 				return createView(filePathFromViewRoot, new ThymeleafModel());
 			}
@@ -42,6 +46,15 @@ public class CityWalkView extends JaxrsView {
 			return createView("/index.html", new ThymeleafModel());
 		}
 
+	}
+
+	private boolean isFromServiceWorker(Map<String, String[]> params) {
+		for (String key : params.keySet()) {
+			if (key.equalsIgnoreCase("serviceWorker")) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	private boolean isUnneededLogin(String filePathFromViewRoot) {

--- a/src/main/webapp/fragment/header.html
+++ b/src/main/webapp/fragment/header.html
@@ -3,6 +3,7 @@
 <head th:fragment="meta-fragment">
 <meta http-equiv="content-type" content="text/html; charset=UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0">
+<script src="../sw-register.js"></script>
 <link rel="stylesheet"
   href="//cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/css/bootstrap.min.css" />
 <link rel="stylesheet"

--- a/src/main/webapp/fragment/header.html
+++ b/src/main/webapp/fragment/header.html
@@ -3,7 +3,6 @@
 <head th:fragment="meta-fragment">
 <meta http-equiv="content-type" content="text/html; charset=UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0">
-<script src="../sw-register.js"></script>
 <link rel="stylesheet"
   href="//cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/css/bootstrap.min.css" />
 <link rel="stylesheet"

--- a/src/main/webapp/jaxrs-view-root/checkpoints.html
+++ b/src/main/webapp/jaxrs-view-root/checkpoints.html
@@ -1,6 +1,7 @@
 <!DOCTYPE HTML>
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:th="http://www.thymeleaf.org" lang="ja">
 <head>
+<script src="../sw-register.js"></script>
 <object th:include="/fragment/header.html :: meta-fragment" th:remove="tag"></object>
 <script
   src="https://maps.googleapis.com/maps/api/js?key=AIzaSyCyGENOzS6lKjopS39UlIzljj5lj7Pl1ss&libraries=geometry"></script>

--- a/src/main/webapp/js/navi.js
+++ b/src/main/webapp/js/navi.js
@@ -17,7 +17,7 @@ var infoWindow;
 var uaParser = new UAParser();
 
 window.onload = function() {
-  initMap();
+  setTimeout(initMap, 300);
 }
 
 // ブラウザがバックグラウンドに一度遷移すると，watchPositionキャンセルされる。
@@ -163,7 +163,7 @@ function initMap() {
     fillColor: '#C2D3E3'
   });
   currentPositionMarker.setMap(map);
-  
+
   watchCurrentPosition();
 }
 

--- a/src/main/webapp/js/task-common.js
+++ b/src/main/webapp/js/task-common.js
@@ -79,7 +79,6 @@ function setTaskTitle() {
 }
 
 function addActivity(task, input, isCorrect) {
-
   var checkpointId = getParam("checkpoint_id");
   var arg = {
     checkpointId: checkpointId,
@@ -95,50 +94,38 @@ function addActivity(task, input, isCorrect) {
     }
   };
 
-  showLoading();
-  new JsonRpcClient(new JsonRpcRequest(getBaseUrl(), "addActivity", [arg], function(data) {
-    hideLoading();
-    setCheckpointProgress(checkpointId, getTaskIndex()); // 完了済みtask
-    // indexを保存
-    if (isLastTask()) {
-      addVisitedCheckPointIds(checkpointId); // 訪問済みチェックポイントに追加
-    }
-    var title = "";
-    if (isCheckin()) {
-      title = "チェックイン完了";
+  addItems(KEY_ACTIVITIES, [arg]);
+
+  setCheckpointProgress(checkpointId, getTaskIndex()); // 完了済みtask
+  // indexを保存
+  if (isLastTask()) {
+    addVisitedCheckPointIds(checkpointId); // 訪問済みチェックポイントに追加
+  }
+  var title = "";
+  if (isCheckin()) {
+    title = "チェックイン完了";
+    title += "<br>" + arg.score + "pt獲得しました！";
+  } else {
+    if (isCorrect) {
+      title += "<br>正解！"
       title += "<br>" + arg.score + "pt獲得しました！";
     } else {
-      if (isCorrect) {
-        title += "<br>正解！"
-        title += "<br>" + arg.score + "pt獲得しました！";
-      } else {
-        title += "<br>不正解！";
-        if (task.taskType === "DescriptionTask") {
-          title += "<br>正解は「" + task.answerTexts.join('」，「') + "」でした．";
-        } else if (task.taskType === "SelectionTask") {
-          var answerTexts = [];
-          for (var i = 0; i < task.selections.length; i++) {
-            if (task.answerIndexes.indexOf(i) >= 0) {
-              answerTexts.push(task.selections[i]);
-            }
+      title += "<br>不正解！";
+      if (task.taskType === "DescriptionTask") {
+        title += "<br>正解は「" + task.answerTexts.join('」，「') + "」でした．";
+      } else if (task.taskType === "SelectionTask") {
+        var answerTexts = [];
+        for (var i = 0; i < task.selections.length; i++) {
+          if (task.answerIndexes.indexOf(i) >= 0) {
+            answerTexts.push(task.selections[i]);
           }
-          title += "<br>正解は「" + answerTexts.join('」，「') + "」でした．";
         }
+        title += "<br>正解は「" + answerTexts.join('」，「') + "」でした．";
       }
     }
-
-    if (data.result && data.result.badges.length > 0) {
-      title = "バッジを獲得しました！";
-      $('#modalDesc').html(data.result.badges.toString().replace(",", "</br>"));
-    }
-    $('#modalTitle').html(title);
-    $('[data-remodal-id=modal]').remodal().open();
-  }, function() {
-    hideLoading();
-    setTimeout(function() {
-      swalAlert("送信失敗", "電波の良いところで，もう一度送信して下さい", "error")
-    }, 500);
-  })).rpc();
+  }
+  $('#modalTitle').html(title);
+  $('[data-remodal-id=modal]').remodal().open();
 }
 
 $(document).on('confirmation', '.remodal', function() {

--- a/src/main/webapp/js/util.js
+++ b/src/main/webapp/js/util.js
@@ -7,6 +7,11 @@ var KEY_MAX_CATEGORY_DEPTH = "max_category_depth";
 var KEY_VISITED_CHECKPOINTS = "visited_checkpoints";
 var KEY_ANSWER_DIC = "answer_dic";
 var KEY_CHECKPOINT_PROGRESS_DIC = "checkpoint_progress_dic";
+var KEY_ACTIVITIES = "activities";
+var KEY_MOVEMENT_LIST = "movement_list";
+
+var POST_ACTIVITY_INTERVAL = 1000 * 8; // msec
+var POST_MOVEMENT_INTERVAL = 1000 * 10; // msec
 /** *********** */
 
 window.addEventListener("load", function() {
@@ -30,7 +35,10 @@ $(function() {
   setUserNameInMenu();
   setBack();
   setForward();
-  setGFormLink();
+  postActivitiesFunc();
+  postMovementsFunc();
+  setInterval(postActivitiesFunc, POST_ACTIVITY_INTERVAL);
+  setInterval(postMovementsFunc, POST_MOVEMENT_INTERVAL);
 });
 
 function isEnableLocalStorage() {
@@ -54,16 +62,6 @@ function showLoading() {
 
 function hideLoading() {
   $("#loading").hide();
-}
-
-function setGFormLink() {
-  $('#gForm')
-          .on(
-                  'click',
-                  function() {
-                    location.href = "https://docs.google.com/forms/d/e/1FAIpQLScluqlpE64IkDjsCaERUtuZL_MUAd4Hfbxwi5o6uUolp498iA/viewform?entry.1317694510="
-                            + encodeURIComponent(getUserId()) + "&entry.1660844838"
-                  });
 }
 
 function setBack() {
@@ -240,6 +238,20 @@ function setItem(key, val) {
 function getItem(key) {
   return window.localStorage.getItem(key);
 }
+
+function getItems(itemsName) {
+  var items = getItem(itemsName);
+  return items ? JSON.parse(items) : [];
+}
+
+function setItems(itemsName, items) {
+  setItem(itemsName, JSON.stringify(items ? items : []));
+}
+
+function addItems(itemsName, items) {
+  setItems(itemsName, getItems(itemsName).concat(items))
+}
+
 // localStorageに保存されている，あるkeyの値を削除する
 function removeItem(key) {
   window.localStorage.removeItem(key);
@@ -339,4 +351,50 @@ function swalAlert(title, text, type, callback) {
     animation: false,
     html: true,
   }, callback);
+}
+
+var postActivitiesFunc = function() {
+  var activities = getItems(KEY_ACTIVITIES);
+  if (activities.length == 0) { return; }
+  removeItem(KEY_ACTIVITIES);
+  activities.forEach(function(activity) {
+    new JsonRpcClient(new JsonRpcRequest(getBaseUrl(), "addActivity", [activity], function(data) {
+      if (data.result && data.result.badges.length > 0) {
+        swalAlert("バッジを獲得！", data.result.badges.toString().replace(",", "</br>"));
+      }
+    }, function(data, textStatus, errorThrown) {
+      addItems(KEY_ACTIVITIES, [activity]);
+    })).rpc();
+  });
+}
+
+/* ローカルストレージにムーブメントを追加する */
+function enqueueMovement(pos) {
+  var movement = {
+    userId: getUserId(),
+    lat: pos.coords.latitude,
+    lon: pos.coords.longitude,
+    accuracy: pos.coords.accuracy,
+    altitude: pos.coords.altitude || -1,
+    altitudeAccuracy: pos.coords.altitudeAccuracy || -1,
+    speed: pos.coords.speed || -1,
+    heading: cHeading,
+    checkpointGroupId: getCheckpointGroupId(),
+    checkpointId: checkpoint.id,
+    recordedAt: Date.now(),
+  };
+  addItems(KEY_MOVEMENT_LIST, [movement]);
+}
+
+/* 一定周期で呼び出され，ムーブメントを送信する */
+var postMovementsFunc = function() {
+  var movements = getItems(KEY_MOVEMENT_LIST);
+  if (movements.length == 0) { return; }
+  removeItem(KEY_MOVEMENT_LIST); // クリア
+  new JsonRpcClient(new JsonRpcRequest(getBaseUrl(), "addMovements", [movements], function(data) {
+    // console.log(data);
+  }, function(data, textStatus, errorThrown) {
+    // リストア
+    setItems(KEY_MOVEMENT_LIST, movements.concat(getItems(KEY_MOVEMENT_LIST)));
+  })).rpc();
 }

--- a/src/main/webapp/sw-register.js
+++ b/src/main/webapp/sw-register.js
@@ -1,0 +1,10 @@
+if ('serviceWorker' in navigator) {
+  // , {'scope': '/magcruise-citywalk'}
+  navigator.serviceWorker.register('../sw.js').then(function(registration) {
+    // 登録成功
+    console.log('ServiceWorker registration successful with scope: ', registration.scope);
+  }).catch(function(err) {
+    // 登録失敗
+    console.log('ServiceWorker registration failed: ', err);
+  });
+}

--- a/src/main/webapp/sw-register.js
+++ b/src/main/webapp/sw-register.js
@@ -1,10 +1,7 @@
 if ('serviceWorker' in navigator) {
-  // , {'scope': '/magcruise-citywalk'}
   navigator.serviceWorker.register('../sw.js').then(function(registration) {
-    // 登録成功
     console.log('ServiceWorker registration successful with scope: ', registration.scope);
   }).catch(function(err) {
-    // 登録失敗
-    console.log('ServiceWorker registration failed: ', err);
+    console.error('ServiceWorker registration failed: ', err);
   });
 }

--- a/src/main/webapp/sw.js
+++ b/src/main/webapp/sw.js
@@ -1,81 +1,29 @@
-'use strict';
+var VERSION = 1;
+var CACHE_NAME = 'cache-v'+VERSION;
 
-const CACHE_NAME = 'cache-v1';
-const ROOT = '/magcruise-citywalk/'
-const urlsToCache = [
-   ROOT + 'css/checkpoints.css',
-   ROOT + 'css/common.css',
-   ROOT + 'css/header.css',
-   ROOT + 'css/navi.css',
-   ROOT + 'css/remodal-default-theme.css',
-   ROOT + 'css/remodal.css',
-   ROOT + 'css/task-selection.css',
-   ROOT + 'img/back.svg',
-   ROOT + 'img/forward.svg',
-   ROOT + 'img/btn_nav_start.png',
-   ROOT + 'img/loading.gif',
-   ROOT + 'img/next_button.svg',
-   ROOT + 'img/nopicture.svg',
-   ROOT + 'img/placeholder.svg',
-   ROOT + 'app/checkpoints.html',
-   ROOT + 'app/check-environment.html',
-   ROOT + 'app/task-description.html',
-   ROOT + 'app/task-pin.html',
-   ROOT + 'app/task-qr.html',
-   ROOT + 'app/task-selection.html',
-   ROOT + 'js/checkpoints.js',
-   ROOT + 'js/lib/jsonrpc.js',
-   ROOT + 'js/navi.js',
-   ROOT + 'js/lib/parseUri.js',
-   ROOT + 'js/lib/remodal.min.js',
-   ROOT + 'js/task-common.js',
-   ROOT + 'js/task-description.js',
-   ROOT + 'js/task-photo.js',
-   ROOT + 'js/task-pin.js',
-   ROOT + 'js/task-qr.js',
-   ROOT + 'js/task-selection.js',
-   ROOT + 'js/util.js',
-
-];
-
-self.addEventListener('install', (event) => {
-    event.waitUntil(
-        caches.open(CACHE_NAME)
-              .then((cache) => {
-                  // 指定されたリソースをキャッシュに追加する
-                  return cache.addAll(urlsToCache);
-              })
-    );
-});
+function exchangeCitywalkUrl(url){
+  if(url.indexOf("magcruise-citywalk") !=-1 &&url.indexOf("?")!=-1){
+    return url.substring(0,url.indexOf("?"));
+  }else{
+    return url;
+  }
+}
 
 self.addEventListener('fetch', (event) => {
-    event.respondWith(
-        caches.match(event.request)
-              .then((response) => {
-                  if (response) {
-                      return response;
-                  }
-                  // 重要：リクエストを clone する。リクエストは Stream なので
-                  // 一度しか処理できない。ここではキャッシュ用、fetch 用と2回
-                  // 必要なので、リクエストは clone しないといけない
-                  let fetchRequest = event.request.clone();
-                  return fetch(fetchRequest)
-                      .then((response) => {
-                          if (!response || response.status !== 200 || response.type !== 'basic') {
-                              return response;
-                          }
-                          // 重要：レスポンスを clone する。レスポンスは Stream で
-                          // ブラウザ用とキャッシュ用の2回必要。なので clone して
-                          // 2つの Stream があるようにする
-                          let responseToCache = response.clone();
-                          caches.open(CACHE_NAME)
-                                .then((cache) => {
-                                  if(event.request.method==="GET"){
-                                    cache.put(event.request, responseToCache);
-                                  }
-                                });
-                          return response;
-                      });
-              })
-    );
+  var res = fetch(event.request).then((response) => {
+      if (!response || response.status !== 200 || response.type !== 'basic') {
+        return response;
+      }
+      let responseToCache = response.clone();
+      caches.open(CACHE_NAME).then((cache) => {
+              if(event.request.method=="GET"){
+                cache.put(exchangeCitywalkUrl(event.request.url), responseToCache);
+              }
+      });
+      return response;
+  }).catch(function(ev) {
+    return caches.match(exchangeCitywalkUrl(event.request.url));
+  });
+
+  event.respondWith(res);
 });

--- a/src/main/webapp/sw.js
+++ b/src/main/webapp/sw.js
@@ -1,15 +1,27 @@
 var VERSION = 1;
 var CACHE_NAME = 'cache-v'+VERSION;
+var DOC_ROOT = location.href.replace("sw.js","")+"app/";
 
-function exchangeCitywalkUrl(url){
-  if(url.indexOf("magcruise-citywalk") !=-1 &&url.indexOf("?")!=-1){
-    return url.substring(0,url.indexOf("?"));
-  }else{
-    return url;
-  }
-}
+self.addEventListener('activate', function(evt) {
+  evt.waitUntil(
+    caches.keys().then(function(keys) {
+          var promises = [];
+          keys.forEach(function(cacheName) {
+              promises.push(caches.delete(cacheName));
+          });
+          return Promise.all(promises);
+    }));
+});
 
 self.addEventListener('fetch', (event) => {
+  function exchangeCitywalkUrl(url){
+    if(url.indexOf("magcruise-citywalk") !=-1 &&url.indexOf("?")!=-1){
+      return url.substring(0,url.indexOf("?"));
+    }else{
+      return url;
+    }
+  }
+
   var res = fetch(event.request).then((response) => {
       if (!response || response.status !== 200 || response.type !== 'basic') {
         return response;

--- a/src/main/webapp/sw.js
+++ b/src/main/webapp/sw.js
@@ -70,7 +70,9 @@ self.addEventListener('fetch', (event) => {
                           let responseToCache = response.clone();
                           caches.open(CACHE_NAME)
                                 .then((cache) => {
+                                  if(event.request.method==="GET"){
                                     cache.put(event.request, responseToCache);
+                                  }
                                 });
                           return response;
                       });

--- a/src/main/webapp/sw.js
+++ b/src/main/webapp/sw.js
@@ -22,6 +22,10 @@ self.addEventListener('fetch', (event) => {
     }
   }
 
+  function isCitywalkHtmlUrl(url){
+    return url.indexOf(DOC_ROOT)!=-1 && url.indexOf(".html")!=-1;
+  }
+
   var res = fetch(event.request).then((response) => {
       if (!response || response.status !== 200 || response.type !== 'basic') {
         return response;
@@ -34,7 +38,13 @@ self.addEventListener('fetch', (event) => {
       });
       return response;
   }).catch(function(ev) {
-    return caches.match(exchangeCitywalkUrl(event.request.url));
+    return caches.match(exchangeCitywalkUrl(event.request.url)).then((response)=>{
+        if(!response && isCitywalkHtmlUrl(event.request.url)){
+          return caches.match(DOC_ROOT+"checkpoints.html");
+        }
+        return response;
+      }
+    );
   });
 
   event.respondWith(res);

--- a/src/main/webapp/sw.js
+++ b/src/main/webapp/sw.js
@@ -39,12 +39,16 @@ self.addEventListener('fetch', (event) => {
       return response;
   }).catch(function(ev) {
     return caches.match(exchangeCitywalkUrl(event.request.url)).then((response)=>{
-        if(!response && isCitywalkHtmlUrl(event.request.url)){
-          return caches.match(DOC_ROOT+"checkpoints.html");
-        }
-        return response;
+      if(!response && isCitywalkHtmlUrl(event.request.url)){
+        return caches.match(exchangeCitywalkUrl(event.request.referrer)).then((response)=>{
+          if(!response && isCitywalkHtmlUrl(event.request.url)){
+            return caches.match(DOC_ROOT+"checkpoints.html");
+          }
+          return response;
+        });
       }
-    );
+      return response;
+    });
   });
 
   event.respondWith(res);

--- a/src/main/webapp/sw.js
+++ b/src/main/webapp/sw.js
@@ -1,0 +1,79 @@
+'use strict';
+
+const CACHE_NAME = 'cache-v1';
+const ROOT = '/magcruise-citywalk/'
+const urlsToCache = [
+   ROOT + 'css/checkpoints.css',
+   ROOT + 'css/common.css',
+   ROOT + 'css/header.css',
+   ROOT + 'css/navi.css',
+   ROOT + 'css/remodal-default-theme.css',
+   ROOT + 'css/remodal.css',
+   ROOT + 'css/task-selection.css',
+   ROOT + 'img/back.svg',
+   ROOT + 'img/forward.svg',
+   ROOT + 'img/btn_nav_start.png',
+   ROOT + 'img/loading.gif',
+   ROOT + 'img/next_button.svg',
+   ROOT + 'img/nopicture.svg',
+   ROOT + 'img/placeholder.svg',
+   ROOT + 'app/checkpoints.html',
+   ROOT + 'app/check-environment.html',
+   ROOT + 'app/task-description.html',
+   ROOT + 'app/task-pin.html',
+   ROOT + 'app/task-qr.html',
+   ROOT + 'app/task-selection.html',
+   ROOT + 'js/checkpoints.js',
+   ROOT + 'js/lib/jsonrpc.js',
+   ROOT + 'js/navi.js',
+   ROOT + 'js/lib/parseUri.js',
+   ROOT + 'js/lib/remodal.min.js',
+   ROOT + 'js/task-common.js',
+   ROOT + 'js/task-description.js',
+   ROOT + 'js/task-photo.js',
+   ROOT + 'js/task-pin.js',
+   ROOT + 'js/task-qr.js',
+   ROOT + 'js/task-selection.js',
+   ROOT + 'js/util.js',
+
+];
+
+self.addEventListener('install', (event) => {
+    event.waitUntil(
+        caches.open(CACHE_NAME)
+              .then((cache) => {
+                  // 指定されたリソースをキャッシュに追加する
+                  return cache.addAll(urlsToCache);
+              })
+    );
+});
+
+self.addEventListener('fetch', (event) => {
+    event.respondWith(
+        caches.match(event.request)
+              .then((response) => {
+                  if (response) {
+                      return response;
+                  }
+                  // 重要：リクエストを clone する。リクエストは Stream なので
+                  // 一度しか処理できない。ここではキャッシュ用、fetch 用と2回
+                  // 必要なので、リクエストは clone しないといけない
+                  let fetchRequest = event.request.clone();
+                  return fetch(fetchRequest)
+                      .then((response) => {
+                          if (!response || response.status !== 200 || response.type !== 'basic') {
+                              return response;
+                          }
+                          // 重要：レスポンスを clone する。レスポンスは Stream で
+                          // ブラウザ用とキャッシュ用の2回必要。なので clone して
+                          // 2つの Stream があるようにする
+                          let responseToCache = response.clone();
+                          caches.open(CACHE_NAME)
+                                .then((cache) => {
+                                    cache.put(event.request, responseToCache);
+                                });
+                          return response;
+                      });
+              })
+    );
+});

--- a/src/main/webapp/sw.js
+++ b/src/main/webapp/sw.js
@@ -1,6 +1,23 @@
 var VERSION = 1;
 var CACHE_NAME = 'cache-v'+VERSION;
-var DOC_ROOT = location.href.replace("sw.js","")+"app/";
+var DOC_ROOT = location.href.replace("sw.js","");
+var HTMLS = ["clear.html","dev.html","index.html","task-description.html","badge.html","task-photo.html",
+             "task-qr.html","task-selection.html","visit-history.html","score.html","navi.html","task-pin.html",
+             "login.html","how-to-use.html","courses.html","help.html","credits.html","intro.html","tutorial.html",
+             "signup.html","troubleshooting.html","check-environment.html","checkpoints.html"];
+var JSS=["lib/parseUri.js","lib/remodal.min.js","lib/ua-parser.min.js","lib/hammer-time.min.js","lib/geolocation-marker.js","lib/jsonrpc.js",
+         "citywalk-dev.js","score.js","task-qr.js","task-photo.js","visit-history.js","clear.js","task-common.js",
+         "task-description.js","checkpoint-util.js","map-util.js","courses.js","login.js","util.js","troubleshooting.js",
+         "tutorial.js","intro.js","signup.js","task-selection.js","task-pin.js","badge.js","check-environment.js","checkpoints.js","navi.js"];
+var CSSS=["remodal.css","remodal-default-theme.css","task-selection.css","badge.css","carousel.css",
+          "credits.css","doc-page.css","score.css","task-photo.css","task-qr.css","tutorial.css",
+          "visit-history.css","top.css","courses.css","common.css","checkpoints.css","header.css","navi.css"];
+var IMGS=["arrow.png","btn_current_position.png","next_button.svg","nopicture.svg",
+          "placeholder.svg","loading.gif","rank_first.png","rank_second.png",
+          "rank_third.png","back.svg","forward.svg","btn_nav_start.png",
+          "web/here.png","web/gps-alert.png","web/gps-chrome.png","web/gps-safari-alert.png","web/checkin.png",
+          "web/navi.png","web/checkpoints.png","web/score.png","web/signup.png","web/task.png",
+          "web/visit-history.png","web/gps-ios-app.png","web/gps-android.png"];
 
 self.addEventListener('activate', function(evt) {
   evt.waitUntil(
@@ -11,6 +28,34 @@ self.addEventListener('activate', function(evt) {
           });
           return Promise.all(promises);
     }));
+  evt.waitUntil(
+          caches.open(CACHE_NAME).then((cache) => {
+            HTMLS.forEach(function(fileName){
+              var path = DOC_ROOT+"app/"+fileName;
+              fetch(path+"?serviceWorker=true").then(function (response) {
+                return cache.put(path, response);
+              })
+            });
+            JSS.forEach(function(fileName){
+              var path = DOC_ROOT+"js/"+fileName;
+              fetch(path).then(function (response) {
+                return cache.put(path, response);
+              })
+            });
+            CSSS.forEach(function(fileName){
+              var path = DOC_ROOT+"css/"+fileName;
+              fetch(path).then(function (response) {
+                return cache.put(path, response);
+              })
+            });
+            IMGS.forEach(function(fileName){
+              var path = DOC_ROOT+"img/"+fileName;
+              fetch(path).then(function (response) {
+                return cache.put(path, response);
+              })
+            });
+          })
+        );
 });
 
 self.addEventListener('fetch', (event) => {


### PR DESCRIPTION
### ServiceWorkerの修正
#138との違い
- citywalkのjaxrs-view-root，js，css，img以下は最初にキャッシュする．
- checkpoints.htmlでだけsw.jsを読み込む．(そうでなくても良かったかも．)
- ``navi.html?hogehoge``, ``checkpoints.html?hugagufa``は，``navi.html``や``checkpoints.html``と常に同じHTMLを取得すれば良い．そういったhtmlだけパラメータを外してキャッシュした．(https://github.com/MAGCruise/magcruise-citywalk/pull/218/files#diff-ba1e5526e6e3632c100cace15b71043dR17)
- どのリソースでもアクセスしたら，キャッシュする．キャッシュは上書きする．
- #138 は，キャッシュを確認，キャッシュになかったらネットワークからフェッチしている．変なリダイレクトをキャッシュしたり，ページの更新がかからないという問題がある．通信量削減にはつながらないが，基本はネットワークからフェッチ，失敗するときだけキャッシュから取り出すというようにした．

#216 #20 #138 

### addActivityのオフライン対応
- #216 addActivityをlocalStorageに溜めてから送信するようにした．